### PR TITLE
fix(usd): author a safe initial joint state for the RS arm

### DIFF
--- a/usd/RS-rebot-dev-arm/payloads/Physics/physics.usda
+++ b/usd/RS-rebot-dev-arm/payloads/Physics/physics.usda
@@ -132,7 +132,8 @@ over "tn__00armrs_asmv3_hJ6D"
         {
             float drive:angular:physics:damping = 60
             float drive:angular:physics:stiffness = 500
-            float drive:angular:physics:targetPosition = 0
+            float drive:angular:physics:targetPosition = 0.0
+            float state:angular:physics:position = 0.0
             uniform token drive:angular:physics:type = "force"
             float newton:velocityLimit = 2864.789
             uniform token physics:axis = "Z"
@@ -155,7 +156,8 @@ over "tn__00armrs_asmv3_hJ6D"
         {
             float drive:angular:physics:damping = 96
             float drive:angular:physics:stiffness = 1500
-            float drive:angular:physics:targetPosition = 0
+            float drive:angular:physics:targetPosition = -90
+            float state:angular:physics:position = -90
             uniform token drive:angular:physics:type = "force"
             float newton:velocityLimit = 2864.789
             uniform token physics:axis = "Z"
@@ -178,7 +180,8 @@ over "tn__00armrs_asmv3_hJ6D"
         {
             float drive:angular:physics:damping = 76
             float drive:angular:physics:stiffness = 1000
-            float drive:angular:physics:targetPosition = 0
+            float drive:angular:physics:targetPosition = -1
+            float state:angular:physics:position = -1
             uniform token drive:angular:physics:type = "force"
             float newton:velocityLimit = 2864.789
             uniform token physics:axis = "Z"
@@ -201,7 +204,8 @@ over "tn__00armrs_asmv3_hJ6D"
         {
             float drive:angular:physics:damping = 18
             float drive:angular:physics:stiffness = 150
-            float drive:angular:physics:targetPosition = 0
+            float drive:angular:physics:targetPosition = 0.0
+            float state:angular:physics:position = 0.0
             uniform token drive:angular:physics:type = "force"
             float newton:velocityLimit = 2291.8313
             uniform token physics:axis = "Z"
@@ -225,6 +229,7 @@ over "tn__00armrs_asmv3_hJ6D"
             float drive:angular:physics:damping = 10
             float drive:angular:physics:stiffness = 80
             float drive:angular:physics:targetPosition = 0
+            float state:angular:physics:position = 0
             uniform token drive:angular:physics:type = "force"
             float newton:velocityLimit = 2291.8313
             uniform token physics:axis = "Z"
@@ -247,7 +252,8 @@ over "tn__00armrs_asmv3_hJ6D"
         {
             float drive:angular:physics:damping = 7
             float drive:angular:physics:stiffness = 50
-            float drive:angular:physics:targetPosition = 0
+            float drive:angular:physics:targetPosition = 0.0
+            float state:angular:physics:position = 0.0
             uniform token drive:angular:physics:type = "force"
             float newton:velocityLimit = 2291.8313
             uniform token physics:axis = "Z"
@@ -270,7 +276,8 @@ over "tn__00armrs_asmv3_hJ6D"
         {
             float drive:linear:physics:damping = 4
             float drive:linear:physics:stiffness = 100
-            float drive:linear:physics:targetPosition = 0
+            float drive:linear:physics:targetPosition = 0.02
+            float state:linear:physics:position = 0.02
             uniform token drive:linear:physics:type = "force"
             float newton:velocityLimit = 10
             uniform token physics:axis = "Z"
@@ -293,7 +300,8 @@ over "tn__00armrs_asmv3_hJ6D"
         {
             float drive:linear:physics:damping = 4
             float drive:linear:physics:stiffness = 100
-            float drive:linear:physics:targetPosition = 0
+            float drive:linear:physics:targetPosition = 0.02
+            float state:linear:physics:position = 0.02
             uniform token drive:linear:physics:type = "force"
             float newton:velocityLimit = 10
             uniform token physics:axis = "Z"


### PR DESCRIPTION
## Problem

The RS arm USD (`usd/RS-rebot-dev-arm`) opens with all drive `targetPosition = 0` and no authored joint state. For this arm, **q=0 is a degenerate configuration**:

- the arm lies **flat over the tabletop workspace** — it occludes any overhead/tripod camera and intersects table-height scene props the moment you add them;
- `joint2`/`joint3` sit **exactly on their upper limit** (0° of a [−179.9°, 0°] range) and both fingers on their lower limit. Parking on a limit is a boundary condition for position controllers and for any tooling that validates targets against limits with a safety margin (the first commanded interpolation step gets rejected).

## Fix

Author `PhysicsJointStateAPI` positions and matching drive targets so the stage opens with the arm **standing straight up** (the product presentation pose), interior to every joint range:

| joint | value |
|---|---|
| joint1, joint4, joint5, joint6 | 0° |
| joint2 | −90° (vertical) |
| joint3 | −1° (kept 1° inside its 0° limit) |
| joint_left, joint_right | 0.02 m (off the 0 lower limit) |

## Validation

Opened on Isaac Sim 6.0 (PhysX): the stage loads with the arm statically holding the authored pose — vertical, clear of the table, drives stable (no sag, no limit violation on first motion commands).

Found while wiring this asset into an agentic pick-and-place demo (DGX Spark + Isaac Sim 6.0), where the flat-at-limits spawn both blocked the workspace camera and tripped the motion controller's joint-limit margin check on the very first move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)