### PR TITLE
Add MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Seeed Studio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

Adds an explicit **MIT License** (`LICENSE`) to the repository.

The repo currently ships no top-level license file, which leaves its
redistribution terms ambiguous for downstream users. Seeed Studio releases the
reBot DevArm assets under the MIT License, so this adds the standard MIT text
with the copyright attributed to Seeed Studio.

## Why

- Gives the repo a machine-detectable license (GitHub's license picker, SPDX
  scanners, etc.).
- Unblocks downstream redistribution of the geometry and physical parameters —
  in particular the structured-USD conversion of this arm contributed to
  [`newton-physics/newton-assets`](https://github.com/newton-physics/newton-assets/pull/45),
  where reviewers asked for the upstream license to be confirmed and documented.

## Contents

- `LICENSE` — standard MIT License, `Copyright (c) 2026 Seeed Studio`.

Happy to adjust the copyright holder / year if Seeed prefers different wording
(cc @ZhuYaoHui1998).