### PR TITLE
Fix swinging gripper: the finger drives are 10x too soft

### DIFF
--- a/mjcf/rebot_devarm/build_mjcf.py
+++ b/mjcf/rebot_devarm/build_mjcf.py
@@ -33,10 +33,21 @@ OUT = HERE / "rebot_devarm.xml"
 INERTIA_KEYS = ("ixx", "iyy", "izz", "ixy", "ixz", "iyz")
 JOINT_TYPES = {"revolute": "hinge", "prismatic": "slide"}
 # class -> (joint damping, kp, kv, forcerange): hardware-validated PD gains
+#
+# The gripper gains are NOT hardware-validated in the same sense as rs06/rs00:
+# they set how hard the simulated fingers hold their commanded opening. kp=100
+# against a 0.0752 kg finger leaves x = mg/k = 7.4 mm of droop at worst
+# orientation, and measured in Isaac Sim the fingers drifted 3.8 mm during an
+# arm sweep and stayed there -- the gripper reads as swinging freely. Error
+# scales as 1/kp (2.92 -> 0.92 -> 0.21 mm for kp = 100 -> 300 -> 1000), i.e. a
+# soft drive rather than force saturation (forcerange is +-500 N; holding a
+# finger needs ~0.74 N). kp=1000 matches the reference Panda gripper for a
+# comparable finger mass; kv rises with it to keep the damping ratio so the
+# droop does not become ringing.
 DYNAMICS = {
     "rs06": ("5", "900", "60", "-36 36"),
     "rs00": ("2", "120", "10", "-14 14"),
-    "gripper": ("1", "100", "4", "-500 500"),
+    "gripper": ("1", "1000", "40", "-500 500"),
 }
 JOINT_CLASS = {
     "joint1": "rs06",

--- a/mjcf/rebot_devarm/rebot_devarm.xml
+++ b/mjcf/rebot_devarm/rebot_devarm.xml
@@ -18,7 +18,7 @@
       </default>
       <default class="gripper">
         <joint damping="1" />
-        <position kp="100" kv="4" forcerange="-500 500" />
+        <position kp="1000" kv="40" forcerange="-500 500" />
       </default>
     </default>
   </default>

--- a/usd/RS-rebot-dev-arm/payloads/RS-rebot-dev-arm_physics.usd
+++ b/usd/RS-rebot-dev-arm/payloads/RS-rebot-dev-arm_physics.usd
@@ -423,9 +423,9 @@ over "tn__00armrs_asmv3_hJ6D"
             prepend apiSchemas = ["PhysicsDriveAPI:linear", "PhysicsJointStateAPI:linear", "PhysxJointAPI"]
         )
         {
-            float drive:linear:physics:damping = 4
+            float drive:linear:physics:damping = 40
             float drive:linear:physics:maxForce = 500
-            float drive:linear:physics:stiffness = 100
+            float drive:linear:physics:stiffness = 1000
             float drive:linear:physics:targetPosition = 0
             uniform token drive:linear:physics:type = "force"
             float newton:linear:limitDamping = 100
@@ -451,9 +451,9 @@ over "tn__00armrs_asmv3_hJ6D"
             prepend apiSchemas = ["PhysicsDriveAPI:linear", "PhysicsJointStateAPI:linear", "PhysxJointAPI"]
         )
         {
-            float drive:linear:physics:damping = 4
+            float drive:linear:physics:damping = 40
             float drive:linear:physics:maxForce = 500
-            float drive:linear:physics:stiffness = 100
+            float drive:linear:physics:stiffness = 1000
             float drive:linear:physics:targetPosition = 0
             uniform token drive:linear:physics:type = "force"
             float newton:linear:limitDamping = 100

--- a/usd/RS-rebot-dev-arm/scripts/prep_asset.py
+++ b/usd/RS-rebot-dev-arm/scripts/prep_asset.py
@@ -46,6 +46,16 @@ ROOT = "/tn__00armrs_asmv3_hJ6D"
 
 # joint -> (drive kind, stiffness, damping). Validated 2026-07-07 (8/8 pass,
 # errors ~1e-5 rad, Newton/PhysX parity; gt_analysis_2026-07-07/joint_drives.csv).
+#
+# The gripper pair was re-tuned 2026-07-31. At (100, 4) the fingers do not hold
+# their commanded opening while the arm accelerates: measured in Isaac Sim they
+# drift 3.8 mm off target during an arm sweep and STAY there, which reads as a
+# gripper swinging freely. Error scales as 1/stiffness (2.92 -> 0.92 -> 0.21 mm
+# for k = 100 -> 300 -> 1000), so the drive is soft rather than saturating
+# (maxForce is 500 N; holding a 0.0752 kg finger needs ~0.74 N, and x = mg/k =
+# 7.4 mm of droop was baked in). (1000, 40) matches the reference Panda gripper
+# for a comparable finger mass and measures 0.36 mm; damping rises with
+# stiffness to preserve the damping ratio so droop does not become ringing.
 GAINS = {
     "joint1": ("angular", 500.0, 60.0),
     "joint2": ("angular", 1500.0, 96.0),
@@ -53,8 +63,8 @@ GAINS = {
     "joint4": ("angular", 150.0, 18.0),
     "joint5": ("angular", 80.0, 10.0),
     "joint6": ("angular", 50.0, 7.0),
-    "joint_left": ("linear", 100.0, 4.0),
-    "joint_right": ("linear", 100.0, 4.0),
+    "joint_left": ("linear", 1000.0, 40.0),
+    "joint_right": ("linear", 1000.0, 40.0),
 }
 
 # joint -> (URDF effort, velocity in USD units). Revolute velocity is deg/s;


### PR DESCRIPTION
Closing this — the diagnosis was wrong, and I should not have opened it.

## What I got wrong

I raised the finger drives 100/4 → 1000/40 on the strength of a stiffness sweep showing error scaling as 1/stiffness. That sweep was real, but I ran it **before** discovering that MuJoCo-Warp was silently discarding every contact past `nconmax=200` in my scene — 4311 dropped-contact errors per boot. Dropped contacts look exactly like a drive that will not hold.

Re-running the same sweep test with the contact cap fixed:

| gains | rest err | sweep err | settled |
|---|---|---|---|
| **100 / 4 (manufacturer)** | **0.00 mm** | **3.66 mm** | 3.61 mm |
| 1000 / 40 (this PR) | 1.60 mm | 4.31 mm | 2.32 mm |

The shipped gains are **not worse** — they are better at rest and equivalent through the sweep. My change bought nothing.

## What I should have checked first

Two things in this repo already answered the question, and I did not read them before opening the PR:

- `usd/RS-rebot-dev-arm/evidence/analysis_2026-07-07/joint_drives.csv` lists the gripper at 100/4 as **manufacturer values**, validated 8/8 with snap-to-limits hold error of **3.8e-08 rad** (joint_left) and **9.7e-08 rad** (joint_right).
- `docs/VALIDATION_SKILL.md` says, in its own words: *"Never retune gains to fix an unstable-looking Newton run until you have isolated collisions. Soft 'critically damped' gains can pass a static settle test while resonating in dynamic tracking and under-holding gravity. Retuning treated the symptom."*

That is precisely the mistake I made. I also never ran the repo's dynamic-tracking protocol (sinusoid amp-ratio / phase lag / step overshoot), so I had no evidence my gains were safe under motion — only a static droop number.

The `mg/k = 7.4 mm` arithmetic in the original description is also not a fault on its own: the fingers are a rack-driven pair with a 500 N effort limit, and the validated hold error shows they track to ~1e-8 rad when contacts are not being dropped.

## The actual bug

`nconmax` on this scene. Worth noting the same evidence package already flagged it — `analysis_2026-07-07/README.md`, finding 6: *"stock 200/1200 overflow instantly with this asset (contacts silently dropped). New defaults 8192/32768."* The asset persists `newton:solver:nconmax`, but the solver still starts at its own default unless the extension-side override is honoured, so the cap has to be raised on the live solver config.

Apologies for the noise. Closing; the companion changes in mujoco_menagerie#300 and newton-assets#45 are being reverted too.
