### PR TITLE
Lower persisted newton:solver:nconmax 8192 -> 4600 (exceeds contact allocation on stock builds)

### DIFF
--- a/usd/RS-rebot-dev-arm/payloads/RS-rebot-dev-arm_physics.usd
+++ b/usd/RS-rebot-dev-arm/payloads/RS-rebot-dev-arm_physics.usd
@@ -34,7 +34,7 @@ over "tn__00armrs_asmv3_hJ6D"
         {
             double[] newton:inertia = [0.0013304, 0.00213119, 0.00275877, 1e-8, 0, 0]
             bool newton:selfCollisionEnabled = 0
-            custom int newton:solver:nconmax = 8192
+            custom int newton:solver:nconmax = 4600
             custom int newton:solver:njmax = 32768
             point3f physics:centerOfMass = (0.0000028764189, -0.00012230249, 0.024337612)
             float3 physics:diagonalInertia = (0.0013304, 0.00213119, 0.00275877)

--- a/usd/RS-rebot-dev-arm/scripts/prep_asset.py
+++ b/usd/RS-rebot-dev-arm/scripts/prep_asset.py
@@ -249,7 +249,19 @@ def author_physics_layer() -> dict:
     )
     ensure_comment(flag, SELF_COLLISION_COMMENT)
     ensure_attr(base, "newton:selfCollisionEnabled", Sdf.ValueTypeNames.Bool, False)
-    ensure_attr(base, "newton:solver:nconmax", Sdf.ValueTypeNames.Int, 8192, custom=True)
+    # nconmax must stay BELOW what Newton allocates for this asset, not just
+    # above the peak contact count. Newton sizes `contacts.rigid_contact_max`
+    # from the geometry -- measured 7020 for this arm on a bare tabletop scene
+    # with stock Isaac Sim 6.0.1 -- and a solver nconmax above that allocation
+    # fails EVERY step with
+    #
+    #   MuJoCo naconmax (8192) exceeds contacts.rigid_contact_max (7020).
+    #
+    # driving the articulation to NaN. 8192 was sized for the patched
+    # newton_stage build in evidence/analysis_2026-07-07; on stock builds it
+    # is unusable. 4600 sits under the allocation and is still ~2.7x the
+    # measured peak during a grasp (1695).
+    ensure_attr(base, "newton:solver:nconmax", Sdf.ValueTypeNames.Int, 4600, custom=True)
     ensure_attr(base, "newton:solver:njmax", Sdf.ValueTypeNames.Int, 32768, custom=True)
 
     drives = 0
@@ -474,7 +486,7 @@ def verify(states: dict) -> None:
     flag = base.GetAttribute("physxArticulation:enabledSelfCollisions")
     assert flag.Get() is False and flag.GetMetadata("comment") == SELF_COLLISION_COMMENT
     assert base.GetAttribute("newton:selfCollisionEnabled").Get() is False
-    assert base.GetAttribute("newton:solver:nconmax").Get() == 8192
+    assert base.GetAttribute("newton:solver:nconmax").Get() == 4600
     assert base.GetAttribute("newton:solver:njmax").Get() == 32768
 
     root = stage.GetPrimAtPath(ROOT)


### PR DESCRIPTION
## Problem

The asset persists `newton:solver:nconmax = 8192`. On **stock Isaac Sim 6.0.1** that value is unusable: Newton sizes `contacts.rigid_contact_max` from the geometry, and a solver `nconmax` above that allocation fails **every step**:

```
[Newton] Simulation step error: MuJoCo naconmax (8192) exceeds
contacts.rigid_contact_max (7020). Create Contacts with at least
rigid_contact_max=8192.
```

The articulation goes NaN within seconds of play, silently — the error appears twice at startup and then the sim just produces NaN state with no further complaint.

`evidence/analysis_2026-07-07/README.md` finding 6 is right that the **stock 200/1200 defaults overflow instantly** with this asset (I measured 1015-1695 contacts, and confirmed the solver silently discards everything past its cap). The 8192/32768 pair fixes that on the patched `newton_stage` build the session used. But on an unpatched build, 8192 lands above the allocation and trades one failure for a worse one.

## Measurements on this build

| quantity | value |
|---|---|
| `contacts.rigid_contact_max` allocated | **7020** |
| peak contacts during a full pick-and-place | **1695** |
| collision shapes total | 229 |

Shape distribution is what drives the allocation — the three `convexDecomposition` gripper prims dominate:

| body | mass | shapes |
|---|---|---|
| gripper_end | 0.6500 kg | 77 |
| finger | 0.0752 kg | 64 |
| finger | 0.0752 kg | 58 |
| link2 | 1.5520 kg | 5 |
| everything else | — | 1-5 each |

199 of 229 shapes (87%) belong to the gripper.

## Change

`8192 -> 4600`: under the 7020 allocation, and still ~2.7x the measured peak demand of 1695. `njmax = 32768` is unchanged — only `nconmax` is bounded by the contact allocation.

Three files, because `prep_asset.py` asserts the USD matches its own table (editing the USD alone breaks the asset's verification pass):

- `usd/RS-rebot-dev-arm/scripts/prep_asset.py` — `ensure_attr` default
- `usd/RS-rebot-dev-arm/scripts/prep_asset.py` — verification assert
- `usd/RS-rebot-dev-arm/payloads/RS-rebot-dev-arm_physics.usd` — the authored value

## Verification

Composed stage resolves `nconmax = 4600`, and with it the arm runs pick-and-place end to end under Newton:

```
pick_and_place  ok=True  23.2s  postcondition confirmed via physics
6-state sweep   6/6 truth, 0 false claims, articulation finite throughout
```

If the intent is to keep 8192 for the patched build, an alternative is to drop the persisted attribute and let consumers set it from the live allocation. Happy to switch to that if you prefer — the reason I went with a lower persisted value is that it works on both builds, whereas 8192 only works on one.

## Note for anyone hitting this downstream

Newton **ignores** the PhysX anti-tunnelling attributes entirely — `physxRigidBody:maxLinearVelocity`, `enableCCD`, `enableSpeculativeCCD` are all no-ops (its model exposes `particle_max_velocity` and no rigid-body speed limit). At `num_substeps=1` and 1/60 s a 5 cm prop needs only ~1.8 m/s to pass straight through a 3 cm tabletop between collision checks. Raising `num_substeps` is the lever that works; this is a scene-side setting, not an asset one, so it is not part of this PR.
