### PR TITLE
Make the gripper finger limits symmetric (0.05 m both)

### DIFF
--- a/reBotArm_Isaacsim/isaacsim_traj_sender.py
+++ b/reBotArm_Isaacsim/isaacsim_traj_sender.py
@@ -77,7 +77,7 @@ DEFAULT_TRAJ_DURATION = 3.0         # 默认轨迹时长（秒）
 DEFAULT_SPEED_SCALE = 1.0           # 速度比例：1.0 = 使用默认时长，>1 更快
 DEFAULT_JOINT_TOLERANCE = 1e-3      # 直发 q 模式下，目标与当前差距过小时跳过规划
 DEFAULT_NULL_GAIN = 0.05            # CLIK 零空间梯度增益（关节限位避让）
-DEFAULT_GRIPPER_MAX_OPENING_M = 0.045  # 夹爪完全打开时每指的滑动距离（米）；保守值，小于 USD upperLimit（左 0.05 / 右 0.0715）
+DEFAULT_GRIPPER_MAX_OPENING_M = 0.045  # 夹爪完全打开时每指的滑动距离（米）；保守值，小于 USD upperLimit（两指均为 0.05）
 
 _running = True
 

--- a/third_party/reBotArm_control_py/urdf/00-arm-rs_asm-v3/urdf/00-arm-rs_asm-v3.urdf
+++ b/third_party/reBotArm_control_py/urdf/00-arm-rs_asm-v3/urdf/00-arm-rs_asm-v3.urdf
@@ -837,7 +837,7 @@
       xyz="0 0 1" />
     <limit
       lower="0"
-      upper="0.0715"
+      upper="0.05"
       effort="500"
       velocity="10" />
   </joint>

--- a/usd/RS-rebot-dev-arm/docs/VALIDATION.md
+++ b/usd/RS-rebot-dev-arm/docs/VALIDATION.md
@@ -50,7 +50,7 @@ published hardware spec are documented here, never silently corrected in the mod
 | J2/J3 range | 180° span ([-180°, 0]) | 220° span | model narrower than spec |
 | J4 range | [-102.6°, +96.8°] | ±90° (vendor URDF and spec agree) | repo URDF is the outlier — recommend reading the firmware limit registers to settle it |
 | wrist velocity (J4–J6) | 40 rad/s | RS-00 no-load 33 rad/s | limit above achievable no-load speed |
-| gripper | 2 independent 500 N prismatic fingers, strokes 0.05 / 0.0715 m | 1 RS-00 driving both fingers via a rack | downstream consumers command both fingers; asymmetric strokes come from CAD |
+| gripper | 2 mimic-coupled 500 N prismatic fingers, stroke 0.05 m each | 1 RS-00 driving both racks from a single pinion | joint_right mimics joint_left with gearing -1 (opposed joint frames), matching the measured 1:1 travel |
 | total mass | 6.009 kg | 6.5–6.7 kg | modeled mass ≈8% light |
 
 ## Known deltas vs the uploaded `usd/RS-rebot-dev-arm`

--- a/usd/RS-rebot-dev-arm/payloads/RS-rebot-dev-arm_physics.usd
+++ b/usd/RS-rebot-dev-arm/payloads/RS-rebot-dev-arm_physics.usd
@@ -460,7 +460,7 @@ def "tn__00armrs_asmv3_hJ6D"
             quatf physics:localRot0 = (-0.49999815, 0.5, 0.5, 0.50000185)
             quatf physics:localRot1 = (1, 0, 0, 0)
             float physics:lowerLimit = 0
-            float physics:upperLimit = 0.0715
+            float physics:upperLimit = 0.05
             float physxJoint:maxJointVelocity = 0.243
             float physxMimicJoint:Z:gearing = -1
             float physxMimicJoint:Z:offset = 0

--- a/usd/RS-rebot-dev-arm/scripts/make_validation_md.py
+++ b/usd/RS-rebot-dev-arm/scripts/make_validation_md.py
@@ -121,7 +121,7 @@ A("| J1 range | ±160.4° (±2.8 rad) | ±150° | model exceeds the spec sheet |
 A("| J2/J3 range | 180° span ([-180°, 0]) | 220° span | model narrower than spec |")
 A("| J4 range | [-102.6°, +96.8°] | ±90° (vendor URDF and spec agree) | repo URDF is the outlier — recommend reading the firmware limit registers to settle it |")
 A("| wrist velocity (J4–J6) | 40 rad/s | RS-00 no-load 33 rad/s | limit above achievable no-load speed |")
-A("| gripper | 2 independent 500 N prismatic fingers, strokes 0.05 / 0.0715 m | 1 RS-00 driving both fingers via a rack | downstream consumers command both fingers; asymmetric strokes come from CAD |")
+A("| gripper | 2 mimic-coupled 500 N prismatic fingers, stroke 0.05 m each | 1 RS-00 driving both racks from a single pinion | joint_right mimics joint_left with gearing -1 (opposed joint frames), matching the measured 1:1 travel |")
 A("| total mass | 6.009 kg | 6.5–6.7 kg | modeled mass ≈8% light |")
 A("")
 A("## Known deltas vs the uploaded `usd/RS-rebot-dev-arm`")


### PR DESCRIPTION
## What

`joint_right` shipped with `upper = 0.0715` while `joint_left` had `upper = 0.05`. Both fingers are driven by one RS-00 pinion turning two opposed racks, so their travel is mechanically identical — the asymmetry came from the CAD URDF export, not from the machine.

## Why this is a bug, not a design choice

Measured on the physical arm (method and full sweeps in `usd/RS-rebot-dev-arm/docs/GRIPPER_RESIDUAL_MOTION.md`):

| | |
| --- | --- |
| driving both fingers to 40 mm | `\|left − right\|` = **0.00000 mm** |
| across every solver setting swept | coupling held 1:1 exactly |
| backlash at the jaw | ±0.37 mm |

A single pinion on two racks cannot produce different strokes per side.

It also left the asset disagreeing with its own documentation: the gripper-coupling work (#21) describes a symmetric 1:1 stroke, while the shipped USD still declared 0.0715 on the right finger. That was my oversight in #21 — the docs were corrected but the USD was not.

## Changes

| file | change |
| --- | --- |
| `usd/RS-rebot-dev-arm/payloads/RS-rebot-dev-arm_physics.usd` | `joint_right` `upperLimit` 0.0715 → 0.05 |
| `third_party/.../00-arm-rs_asm-v3.urdf` | `joint_right` `upper` 0.0715 → 0.05 |
| `usd/RS-rebot-dev-arm/docs/VALIDATION.md` + generator | describe the fingers as mimic-coupled with one stroke, instead of "asymmetric strokes come from CAD" |
| `reBotArm_Isaacsim/isaacsim_traj_sender.py` | comment referenced the old per-finger limits |

Five one-line changes, no behavioural rework.

## Consistency with the other packages

The exported MJCF ([menagerie #300](https://github.com/google-deepmind/mujoco_menagerie/pull/300)) and the newton-assets package ([newton-assets #45](https://github.com/newton-physics/newton-assets/pull/45)) already use `0.05` on both joints. This brings the USD in line with them rather than changing anything downstream.

## Verification

```
Isaac Sim 6.1 (PhysX)
  mimic composed : True
  static  : dev 0.00006 mm
  slewing : dev 0.00629 mm
  VERDICT : PASS

validate_physics_fidelity.py
  failures: []
  MJCF compiles under mujoco 3.10
```

## Context

Found while investigating the SimReady `DJ.007` mimic-joint failures reported in [NVIDIA/simready-foundation#18](https://github.com/NVIDIA/simready-foundation/issues/18). Those failures are a validator issue and reproduce with symmetric limits too, so this change does not affect them — but the asset should be self-consistent regardless.
